### PR TITLE
Adds option for NonDistExperiment to return all metrics

### DIFF
--- a/simvp/api/train.py
+++ b/simvp/api/train.py
@@ -250,7 +250,7 @@ class NonDistExperiment(object):
 
         return val_loss
 
-    def test(self):
+    def test(self, return_all_metrics=False):
         if self.args.test:
             best_model_path = osp.join(self.path, 'checkpoint.pth')
             self.method.model.load_state_dict(torch.load(best_model_path))
@@ -273,4 +273,5 @@ class NonDistExperiment(object):
 
         for np_data in ['metrics', 'inputs', 'trues', 'preds']:
             np.save(osp.join(folder_path, np_data + '.npy'), vars()[np_data])
-        return eval_res['mse']
+
+        return eval_res if return_all_metrics else eval_res['mse']

--- a/tools/non_dist_train.py
+++ b/tools/non_dist_train.py
@@ -32,6 +32,13 @@ if __name__ == '__main__':
     exp.train()
 
     print('>'*35 + ' testing  ' + '<'*35)
-    mse = exp.test()
+
+    return_all_metrics=True
+
+    if return_all_metrics:
+        eval_res = exp.test(return_all_metrics=return_all_metrics)
+        mse = eval_res['mse']
+    else:
+        mse = exp.test()
     if has_nni:
         nni.report_final_result(mse)


### PR DESCRIPTION
- Previously only returned MSE despite calculating multiple metrics
- Default behavior will be to only return MSE to avoid breaking changes
- Change in non_dist_train.py to return all the calculated metrics