### PR TITLE
Adds prev_frame_mse that compares the pred frame to the last input frame

### DIFF
--- a/simvp/api/train.py
+++ b/simvp/api/train.py
@@ -262,8 +262,8 @@ class NonDistExperiment(object):
         if 'weather' in self.args.dataname:
             metric_list, spatial_norm = ['mse', 'rmse', 'mae'], True
         else:
-            metric_list, spatial_norm = ['mse', 'mae', 'ssim', 'psnr', 'fid'], False
-        eval_res, eval_log = metric(preds, trues, self.test_loader.dataset.mean, self.test_loader.dataset.std,
+            metric_list, spatial_norm = ['mse', 'mae', 'ssim', 'psnr', 'fid', 'prev_frame_mse'], False
+        eval_res, eval_log = metric(preds, trues, self.test_loader.dataset.mean, self.test_loader.dataset.std, inputs=inputs,
                                     metrics=metric_list, spatial_norm=spatial_norm)
         metrics = np.array([eval_res['mae'], eval_res['mse']])
         print_log(eval_log)


### PR DESCRIPTION
This change is to add the MSE between the predicted frame `pred` and the last input frame. By adding this metric, we will be able to compare whether the prediction is closer to the `true` label or the last input. If the MSE between the predicted and `true` label is smaller than the MSE between the `pred` and last input frame, we can assume that the model is making a prediction rather than trying to copy the last frame.

Note that this comparison relies on the true label being accurate enough to measure against, and a small `prev_frame_mse` does not necessarily mean that our models are simply copying the last frame. Nonetheless, it will still be interesting to compare these metrics.

I don't love the name `prev_frame_mse`, so if you think of a better name for it, I'm open to suggestions :) 